### PR TITLE
Fixed issue with not adding synonymous amino acid mutations to GeneDi…

### DIFF
--- a/gumpy/difference.py
+++ b/gumpy/difference.py
@@ -118,7 +118,10 @@ class Difference(ABC):
         if len(array) > 0:
             array = numpy.array([item2 for (item1, item2) in array if self.__check_any(item1, item2, False)], dtype=object)
         else:
-            return numpy.array([])
+            #Returning an empty array can cause issues with indels in amino acid sequence not producing same length arrays 
+            #as they are handled separately to other arrays which may contain [None]. This breaks the idea of 1:1 relationship
+            #between values in arrays. So just return None instead of an array
+            return None
         #Check for all None values
         if self.__check_none(array, True):
             return None

--- a/gumpy/difference.py
+++ b/gumpy/difference.py
@@ -669,7 +669,7 @@ class GeneDifference(Difference):
         for (codon1, codon2) in self._codons_full:
             aa1 = codon_to_amino_acid[codon1]
             aa2 = codon_to_amino_acid[codon2]
-            if aa1 != aa2:
+            if codon1 != codon2:
                 aa_diff.append((aa1, aa2))
         return numpy.array(aa_diff)
 

--- a/gumpy/gene.py
+++ b/gumpy/gene.py
@@ -350,9 +350,9 @@ class Gene(object):
         #Match amino acid SNP
         snp = re.compile(r"""
                     ([a-zA-Z_0-9]+@)? #Possibly leading gene name
-                    ([A-Z]) #Reference amino acid
+                    ([A-Z!]) #Reference amino acid
                     ([0-9]+) #Position
-                    ([A-Z]) #Alt amino acid
+                    ([A-Z!]) #Alt amino acid
                     """, re.VERBOSE)
         if self.codes_protein and snp.fullmatch(variant):
             #The variant is an amino acid SNP

--- a/gumpy/gene.py
+++ b/gumpy/gene.py
@@ -366,7 +366,6 @@ class Gene(object):
             valid = valid and int(pos) in self.amino_acid_number
             #Check ref matches the aa seq at the given pos
             valid = valid and self.amino_acid_sequence[self.amino_acid_number == int(pos)] == ref
-            valid = valid and ref != alt
             return valid
 
         #Match amino acid synon-mutation

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -427,6 +427,7 @@ def test_valid_variant():
     assert gene.valid_variant("A@a-2z")
     assert gene.valid_variant("A@8_indel")
     assert gene.valid_variant("A@9=")
+    assert gene.valid_variant("A@K2K")
 
     #Invalid variants
     with pytest.raises(Exception) as e_info:
@@ -452,7 +453,6 @@ def test_valid_variant():
     assert not gene.valid_variant("B@4_ins_a")
     assert not gene.valid_variant(" @K2A")
     assert not gene.valid_variant("gene@a4t")
-    assert not gene.valid_variant("A@K2K")
     assert not gene.valid_variant("a-2a")
     assert not gene.valid_variant("A@28_del_aaccggttaaccggtt")
     assert not gene.valid_variant("20_del_100")


### PR DESCRIPTION
…fference.amino_acid_sequence

This fixes a problem where synonymous mutations would be added identified and added to all appropriate GeneDifference arrays except amino_acid_sequence due to only adding to this if the amino acids differ. This changes to checking if the codons differ - adding synonymous amino acids.