### PR TITLE
Minor fixes for minority populations

### DIFF
--- a/gumpy/gene.py
+++ b/gumpy/gene.py
@@ -195,6 +195,9 @@ class Gene(object):
                 else:
                     #Not coding, so just SNPs
                     ref = reference.nucleotide_sequence[reference.nucleotide_number == pos][0]
+                    #We don't care if these are synonymous
+                    if ref == bases[1]:
+                        continue
                     mutations.append(f"{self.name}@{ref}{pos}{bases[1]}:{cov}")
         
         if self.codes_protein:

--- a/gumpy/variantfile.py
+++ b/gumpy/variantfile.py
@@ -287,9 +287,6 @@ class VCFFile(object):
         seen = []
         
         for (idx, type_) in self.calls.keys():
-            #idx here refers to the position of this call, NOT this vcf row, so adjust to avoid shifting when building minor calls
-            idx = idx - self.calls[(idx, type_)]['pos']
-
             #Check if we've delt with this vcf already
             if self.calls[(idx, type_)]['original_vcf_row'] in seen:
                 continue
@@ -309,6 +306,9 @@ class VCFFile(object):
             dps = list(self.calls[(idx, type_)]['original_vcf_row']["COV"])
 
             total_depth = self.calls[(idx, type_)]['original_vcf_row']['DP']
+            
+            #idx here refers to the position of this call, NOT this vcf row, so adjust to avoid shifting when building minor calls
+            idx = idx - self.calls[(idx, type_)]['pos']
             for (calls, depth) in zip(simple, dps):
                 #As we can have >1 call per simple, iter
                 for call in calls:


### PR DESCRIPTION
2 Fixes:
* Ignore synonymous promoter minor populations
* Don't fix `idx` until after using it as a key during VCF parsing