### PR TITLE
Ensure position is recorded for split deletions

### DIFF
--- a/gumpy/difference.py
+++ b/gumpy/difference.py
@@ -477,7 +477,7 @@ class GeneDifference(Difference):
                 self.nucleotide_index = numpy.append(self.nucleotide_index, [idx])
                 self.amino_acid_number = numpy.append(self.amino_acid_number, [None])
                 self.nucleotide_number = numpy.append(self.nucleotide_number, [None])
-                self.gene_position = numpy.append(self.gene_position, [None])
+                self.gene_position = numpy.append(self.gene_position, [pos])
                 self.is_cds = numpy.append(self.is_cds, [True])
                 self.is_promoter = numpy.append(self.is_promoter, [False])
                 self.is_indel = numpy.append(self.is_indel, [True])


### PR DESCRIPTION
Previously, the `GeneDifference.gene_positions` would have `None` values for deletions which were picked up by splitting a large deletion which began downstream. This ensures that this position is properly propagated