### PR TITLE
Fixes for pulling out gene positions of large dels crossing genes

### DIFF
--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -733,6 +733,7 @@ def test_large_deletions():
 
     assert numpy.all(diff.mutations == ["-1_del_aaaaaaaaccccccccccgggggggggg", 'del_0.93'])
     assert diff.vcf_evidences == [{'GT': (1, 1), 'DP': 2, 'COV': (1, 1), 'GT_CONF': 2.05, 'POS': 2, 'REF': 'aaaaaaaaaccccccccccggggggggggttttttttttaaaaaaaaaaccccccccccggggggggggttttttttttaaaaaaaaaaccc', 'ALTS': ('a',)}, {'GT': (1, 1), 'DP': 2, 'COV': (1, 1), 'GT_CONF': 2.05, 'POS': 2, 'REF': 'aaaaaaaaaccccccccccggggggggggttttttttttaaaaaaaaaaccccccccccggggggggggttttttttttaaaaaaaaaaccc', 'ALTS': ('a',)}]
+    assert diff.nucleotide_number.tolist() == [-1, -1]
 
     b = ref.build_gene("B")
     #Entirely deleted
@@ -741,6 +742,7 @@ def test_large_deletions():
 
     assert numpy.all(diff.mutations == ["del_1.0"])
     assert diff.vcf_evidences == [{'GT': (1, 1), 'DP': 2, 'COV': (1, 1), 'GT_CONF': 2.05, 'POS': 2, 'REF': 'aaaaaaaaaccccccccccggggggggggttttttttttaaaaaaaaaaccccccccccggggggggggttttttttttaaaaaaaaaaccc', 'ALTS': ('a',)}]
+    assert diff.nucleotide_number.tolist() == [1]
 
     c = ref.build_gene("C")
     #Deletes 33%, so reported as normal deletion
@@ -754,6 +756,7 @@ def test_large_deletions():
 
     assert numpy.all(diff.mutations == ["4_del_ggg"])
     assert diff.vcf_evidences == [{'GT': (1, 1), 'DP': 2, 'COV': (1, 1), 'GT_CONF': 2.05, 'POS': 2, 'REF': 'aaaaaaaaaccccccccccggggggggggttttttttttaaaaaaaaaaccccccccccggggggggggttttttttttaaaaaaaaaaccc', 'ALTS': ('a',)}]
+    assert diff.nucleotide_number.tolist() == [4]
 
     #Double check we also get the correct result if C is not revcomp
     #Note that if C is not revcomp, it has a large promoter


### PR DESCRIPTION
Now correctly duplicates variant rows if a deletion crosses >1 gene
If a del starts in an intragene region and then crosses into a gene, it is reported as 2 rows; 1 for the initial start and 1 for the gene it affects.
If a del crosses an intragene region after starting in a gene, no additional rows are reported

Large deletion nucleotide numbers are also now reported properly. Regardless of if >50% of the gene is deleted or not, the nucleotide number reported in these cases is the position of the first deleted base within the gene