### PR TITLE
Vcf fix

### DIFF
--- a/gumpy/gene.py
+++ b/gumpy/gene.py
@@ -246,23 +246,52 @@ class Gene(object):
                     mutations.append(str(pos) + "_" + type_ + "_" + bases + ":" + str(populations[0][coverage]))
             else:
                 self.minor_nc_changes[gene_pos] = nc_changes
-                #We have a mixture here so report as Zs
-                #Other than if we have conflicting indels at a gene index (in that case, crash)
-                c = Counter([(nc_idx, type_) for nc_idx, type_, bases, cov, frs in gene_pos_map[gene_pos]])
-                for (i, t), count in c.items():
-                    if t in ["ins", "del"] and count > 1:
-                        #We have a single index with > 1 indel so complain
-                        assert False, f"A minor population exists in gene {self.name} which has > 1 indel at gene index {i}!"
+                #We have a mixture here so report as Zs for SNPs, indel for indels, and mixed for mixed indels and SNPs
+                c = Counter([(nc_idx, 'indel') if type_ in ['ins', 'del'] else (nc_idx, type_) for nc_idx, type_, bases, cov, frs in gene_pos_map[gene_pos]])
                 
-                cov = max([pop[coverage] for pop in populations])
-                if self.codes_protein and gene_pos > 0:
-                    #These need a little extra effort to pull out the ref AA
-                    ref = self.codon_to_amino_acid[reference.codons[self.amino_acid_number == gene_pos][0]]
-                    mutations.append(ref + str(gene_pos) + "Z:" + str(cov))
+                #Get the number of indels within this codon/base
+                indels = sum([count for (i, t), count in c.items() if t == "indel"])
+                snps = sum([count for (i, t), count in c.items() if t == "snp"])
+
+                if indels > 0 and snps > 0:
+                    #Mixed within the codon/base so return <pos>_mixed
+                    cov = max([pop[coverage] for pop in populations])
+                    mutations.append(str(gene_pos)+"_mixed:"+str(cov))
+                elif indels > 0:
+                    #Just indels, so return of form <pos>_indel
+                    #Little bit more difficult here as we have to check each nucleotide_number
+                    #   this way, if there is only 1 indel per nucleotide, we can be specific
+                    for (i, t), count in c.items():
+                        if count == 1:
+                            #Exactly 1 indel at this position so be specific
+                            #Use the nc_idx instead of gene_pos as they may not be equal
+                            minor = [
+                                (nc_idx, type_, bases, cov, frs) 
+                                for nc_idx, type_, bases, cov, frs 
+                                in gene_pos_map[gene_pos] 
+                                if nc_idx == i
+                            ][0]
+                            mutations.append(str(minor[0]) + "_" + minor[1] + "_" + minor[2] +":" + str(minor[coverage]))
+                        else:
+                            #>1 indel here, so `<pos>_indel` as as accurate as we can be
+                            minors = [
+                                (nc_idx, type_, bases, cov, frs) 
+                                for nc_idx, type_, bases, cov, frs 
+                                in gene_pos_map[gene_pos] 
+                                if nc_idx == i
+                            ]
+                            cov = max([pop[coverage] for pop in minors])
+                            mutations.append(str(minors[0][0])+"_indel:"+str(cov))
                 else:
-                    ref = reference.nucleotide_sequence[self.gene_position == gene_pos][0]
-                    mutations.append(ref + str(gene_pos) + "z:" + str(cov))
-                    
+                    #Just SNPs, so return of form <ref><pos>(z|Z) as appropriate
+                    cov = max([pop[coverage] for pop in populations])
+                    if self.codes_protein and gene_pos > 0:
+                        #These need a little extra effort to pull out the ref AA
+                        ref = self.codon_to_amino_acid[reference.codons[self.amino_acid_number == gene_pos][0]]
+                        mutations.append(ref + str(gene_pos) + "Z:" + str(cov))
+                    else:
+                        ref = reference.nucleotide_sequence[self.gene_position == gene_pos][0]
+                        mutations.append(ref + str(gene_pos) + "z:" + str(cov))
         return sorted(mutations)
 
 

--- a/gumpy/gene.py
+++ b/gumpy/gene.py
@@ -634,7 +634,7 @@ class Gene(object):
         indel = re.compile(r"""
                     ([a-zA-Z_0-9.()]+@)? #Possibly leading gene name
                     (-?[0-9]+) #Position
-                    _(ins|del|indel)_? #Type
+                    _(ins|del|indel|mixed)_? #Type
                     ([0-9]+|[acgtzx]+)? #Bases deleted/inserted
                     """, re.VERBOSE)
         if indel.fullmatch(variant):
@@ -649,8 +649,8 @@ class Gene(object):
                 valid = valid and name[:-1] == self.name
             #Check pos in correct range
             valid = valid and int(pos) in self.nucleotide_number
-            if type_ == "indel":
-                #If a mutation is given as `indel`, no length/bases should be given
+            if type_ == "indel" or type_ == "mixed":
+                #If a mutation is given as `indel` or `mixed`, no length/bases should be given
                 valid = valid and (bases is None or bases == "")
             if type_ == "del" and bases is not None and bases != "":
                 #Mutation was del, so check if the bases given match the ref

--- a/gumpy/genome.py
+++ b/gumpy/genome.py
@@ -848,8 +848,20 @@ class Genome(object):
                 #These only exist due to reference calls
                 #They only made it this far as they are required to pull out minors at these positions
                 pass
+        
+        genome.minor_populations = []
 
-        genome.minor_populations = vcf.minor_populations
+        for minor in vcf.minor_populations:
+            #Ensure that the VCF evidence for these is also recorded correctly
+            pos = minor[0]
+            evidence =  minor[5]
+            
+            #Store the VCF evidence of this
+            genome.vcf_evidence[genome.nucleotide_index[pos - 1]] = evidence
+
+            #Don't keep the VCF evidence with this, as it is already stored in the main vcf_evidence dict
+            genome.minor_populations.append(minor[:5])
+            
         genome.vcf_file = vcf
 
         #Let's assign some deleted regions (if exist)

--- a/tests/unit/test_minor_populations.py
+++ b/tests/unit/test_minor_populations.py
@@ -159,7 +159,10 @@ def test_get_minors():
                                     (7572, 'snp', ('t', 'a'), 2, 0.02), #SNP
                                     (7574, 'snp', ('g', 't'), 10, 0.098), #SNP
         ]
-    assert make_reproducable(vcf.minor_populations) == make_reproducable(expected_minor_populations)
+    #Filter out the VCF evidence from this as we don't really care here
+    actual = make_reproducable([minor[:5] for minor in vcf.minor_populations])
+    expected = make_reproducable(expected_minor_populations) 
+    assert actual == expected
 
     ref = gumpy.Genome("config/NC_000962.3.gbk.gz", is_reference=True, verbose=True)
     sample = ref + vcf

--- a/tests/unit/test_minor_populations.py
+++ b/tests/unit/test_minor_populations.py
@@ -34,11 +34,9 @@ def test_double_del():
     ref_a = ref.build_gene("A")
     sample_a = sample.build_gene("A")
 
-    with pytest.raises(AssertionError):
-        diff = ref_a - sample_a
-        diff.minor_populations()
-    with pytest.raises(AssertionError):
-        sample_a.minority_populations_GARC()
+    diff = ref_a - sample_a
+    assert sorted(diff.minor_populations()) == sorted(['1_del_aa:3', '2_indel:3', '3_del_a:3'])
+    assert sorted(sample_a.minority_populations_GARC()) == sorted(diff.minor_populations())
 
 @pytest.mark.slow
 def test_minor_failures():
@@ -195,24 +193,24 @@ def test_get_minors():
     gyrA_ref = ref.build_gene("gyrA")
 
     assert gyrA.minority_populations_GARC() == sorted([
-                                                        'D94Z:10',
-                                                        'A90Z:10',
+                                                        '94_mixed:10',
+                                                        '90_mixed:10',
                                                         'L91Z:10'
                                                 ])
     assert gyrA.minority_populations_GARC(reference=gyrA_ref) == sorted([
-                                                                        'D94Z:10',
-                                                                        'A90Z:10',
+                                                                        '94_mixed:10',
+                                                                        '90_mixed:10',
                                                                         'S91Z:10',
                                                                     ])
 
     assert gyrA.minority_populations_GARC(interpretation='percentage') == sorted([
-                                                                                'D94Z:0.098',
-                                                                                'A90Z:0.098',
+                                                                                '94_mixed:0.098',
+                                                                                '90_mixed:0.098',
                                                                                 'L91Z:0.098'
                                                                             ])
     assert gyrA.minority_populations_GARC(interpretation='percentage', reference=gyrA_ref) == sorted([
-                                                                                                    'D94Z:0.098',
-                                                                                                    'A90Z:0.098',
+                                                                                                    '94_mixed:0.098',
+                                                                                                    '90_mixed:0.098',
                                                                                                     'S91Z:0.098',
                                                                                                 ])
     


### PR DESCRIPTION
Added fix for a `gnomonicus` edge case

Also ensure that we are as specific as possible within gene level minor calls - moving away from just reporting `Z` for any codon with >1 minor population. Now, if we have >1 minor population within a codon (when codes protein):
* If there is >1 SNP and >1 indel:
    - Report as `<pos>_mixed`
* If there is just >1 SNP:
    - Report as `<ref><pos>Z`
* If there is just >1 indel:  
    - Iterate each base of the codon:
    - If exactly 1 indel at a position, be specific and return bases etc
    - If >1 indel, report as `<pos>_indel`