### PR TITLE
fix: ensure minor populations aren't searched for in null calls

### DIFF
--- a/gumpy/variantfile.py
+++ b/gumpy/variantfile.py
@@ -290,6 +290,9 @@ class VCFFile(object):
                 pos = self.calls[(idx, type_)]['pos']
             else:
                 #Snps
+                if self.calls[(idx, type_)]['call'] == "x":
+                    #Null calls shouldn't have minor populations
+                    continue
                 t = 'snp'
                 bases = (self.calls[(idx, type_)]['ref'], self.calls[(idx, type_)]['call'])
                 pos = self.calls[(idx, type_)]['pos']


### PR DESCRIPTION
This covers the odd edge case where `minos` can give some coverage values despite being a null call - instead ensuring that null calls are skipped when searching for minor populations. 