### PR TITLE
fix: Fix for oxfordmmm/gnomonicus#37

### DIFF
--- a/gumpy/difference.py
+++ b/gumpy/difference.py
@@ -248,7 +248,10 @@ class GenomeDifference(Difference):
             elif evidence2 is not None:
                 evidences.append(evidence2)
                 indices.append(self._get_vcf_idx(evidence2))
-
+            else:
+                evidences.append(None)
+                indices.append(None)
+                
         self.vcf_evidences = evidences
         self.vcf_idx = indices
     


### PR DESCRIPTION
Some kind of edge case is apparently possible where the VCF evidence for a call cannot be found. I'm not entirely sure why that is, possibly to do with disentangling SNPs and indels, but this fixes it by defaulting to `None` when it cannot be found.
The gnomonicus issue this fixes had a test case which has run without errors with this fix in place.

Possible TODO: Find the reason this happens. However, as this is affects 20/44,000 samples, it may not be worth the effort.