### PR TITLE
Additions to enable type checking of this as an import

### DIFF
--- a/gumpy/genome.py
+++ b/gumpy/genome.py
@@ -52,6 +52,7 @@ class Genome(object):
         self.verbose = verbose
         self.is_reference = is_reference
         self.vcf_file: VCFFile | None = None
+        self.gumpy_version: str | None = None
 
         genbank_file = pathlib.Path(genbank_file_)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,4 +31,4 @@ include_package_data = True
 scripts = bin/gumpy-save-genome.py, bin/to_piezo_catalogue.py
 
 [options.package_data]
-mypkg = config/*.gbk, config/*.gbk.gz
+gumpy = config/*.gbk, config/*.gbk.gz, py.typed


### PR DESCRIPTION
This should enable `mypy` to run on `gnomonicus` as expected