### PR TITLE
fix: check for None on filter before `in` check

### DIFF
--- a/gumpy/variantfile.py
+++ b/gumpy/variantfile.py
@@ -566,7 +566,7 @@ class VCFFile(object):
                 not record.is_filter_pass
             ):
                 # We only want to allow these through if the filter fail contains MIN_FRS
-                if "MIN_FRS" in record.filter:
+                if record.filter is not None and "MIN_FRS" in record.filter:
                     # Allow MIN_FRS
                     variant = record.ref
                     variant_type = "ref"


### PR DESCRIPTION
I'd love to know why `mypy` didn't pick up on this. `record.filter` is `list[str] | None`, so can error on an `in` check if `None`